### PR TITLE
Issue #2453489: Panels IPE toolbar is incorrect height, causing blank...

### DIFF
--- a/stylesheets/compass_radix/_panel.scss
+++ b/stylesheets/compass_radix/_panel.scss
@@ -57,3 +57,7 @@ ul.panels-ipe-linkbar {
     }
   }
 }
+
+body.panels-ipe {
+  margin-bottom: 55px !important;
+}


### PR DESCRIPTION
...space to appear at bottom of page