### PR TITLE
Make the spacing on the jQuery UI tabs resemble Panopoly out-of-the-box.

### DIFF
--- a/stylesheets/compass_radix/_maintenance.scss
+++ b/stylesheets/compass_radix/_maintenance.scss
@@ -1,4 +1,75 @@
 // Maintenance page
 // --------------------------------------------------
-.maintenance-page {
+body.maintenance-page {
+
+  // Navbar.
+  // --------------------------------------------------
+  .navbar-logo {
+    float: left;
+    height: 50px;
+    padding: 10px 0;
+    @include breakpoint(sm) {
+      margin-left: $grid-gutter-width / 2;
+      margin-right: $grid-gutter-width / 2;
+    }
+    img {
+      width: 30px;
+      height: auto;
+    }
+  }
+  .navbar-header {
+    float: left;
+    margin-left: 0;
+    @include breakpoint(sm) {
+      margin-left: - ($grid-gutter-width / 2);
+    }
+  }
+  .navbar-right {
+    float: right !important;
+    margin-right: 0;
+    @include breakpoint(sm) {
+      margin-right: - ($grid-gutter-width / 2);
+    }
+  }
+
+  #main {
+    @include breakpoint(md) {
+      padding-top: $grid-gutter-width;
+      padding-bottom: 50px;
+    }
+  }
+
+  // Tasks.
+  // --------------------------------------------------
+  .tasks-list {
+    > div {
+      margin-bottom: 25px;
+      border-left: 3px solid white;
+      padding-left: 20px;
+      h6 {
+        margin-bottom: 2px;
+      }
+      h4 {
+        margin-top: 0;
+      }
+      &.active {
+        border-left-color: black;
+      }
+      &.done {
+        border-left-color: rgba(black, 0.1);
+        @extend .text-muted;
+        @include opacity(0.5);
+      }
+    }
+  }
+
+  // Forms.
+  // --------------------------------------------------
+  .form-actions {
+    .btn {
+      &:first-child {
+        @extend .btn-primary;
+      }
+    }
+  }
 }

--- a/stylesheets/compass_radix/_mixin.scss
+++ b/stylesheets/compass_radix/_mixin.scss
@@ -49,3 +49,10 @@
     @warn "Breakpoint mixin supports: xs, sm, md, lg";
   }
 }
+
+// Font Awesome.
+// -----------------------------------------------------------------------------
+@mixin fa($icon) {
+  @extend .fa;
+  @extend .fa-#{$icon}
+}

--- a/stylesheets/compass_radix/_structure.scss
+++ b/stylesheets/compass_radix/_structure.scss
@@ -238,3 +238,9 @@ ul.dropdown-menu li {
     }
   }
 }
+
+// jQuery UI tabs
+// --------------------------------------------------
+.ui-tabs .ui-tabs-nav {
+  padding: 0 5px 5px 5px;
+}


### PR DESCRIPTION
Here's what the tabs on the Media Browser look like under Panopoly:

![selection_037](https://cloud.githubusercontent.com/assets/191561/6813201/a40921e6-d241-11e4-8048-ab89f19dcb64.png)

Here's what they look like under Radix;

![selection_038](https://cloud.githubusercontent.com/assets/191561/6813203/a9087d22-d241-11e4-92b7-9748d4b6b081.png)

There's too much space above and they are too close the bottom. I think they look better the original way!
