### PR TITLE
Issue #2223365: Remove margin from labels inside .input-group-addon's.

### DIFF
--- a/stylesheets/compass_radix/_form.scss
+++ b/stylesheets/compass_radix/_form.scss
@@ -69,6 +69,10 @@ fieldset {
   }
 }
 
+.input-group-addon label {
+  margin: 0;
+}
+
 html.js {
   input.form-autocomplete {
     background: image-url("throbber.gif") no-repeat right 8px #fff !important;


### PR DESCRIPTION
This is the styling for my patch on https://www.drupal.org/node/2223365